### PR TITLE
Fix CSS issue seen in Chrome after increasing page zoom

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2005,7 +2005,7 @@ a:hover.back-to-top {
     .header {
         position: relative;
         height: 100%;
-        min-height: 50rem;
+        /*min-height: 50rem;*/
     }
 
     .header .header-content {


### PR DESCRIPTION
I was only able to replicate the extended header issue in Chrome after zooming in on the page. Firefox and Safari did not show this problem. I fixed it by commenting out a min-height set in the header's css. 